### PR TITLE
Added OpenOffice 4 Default HOME.

### DIFF
--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
@@ -92,7 +92,8 @@ public class OfficeUtils {
                         programFiles32 + File.separator + "LibreOffice 5",
                         programFiles32 + File.separator + "LibreOffice 4",
                         programFiles32 + File.separator + "LibreOffice 3",
-                        programFiles32 + File.separator + "OpenOffice.org 3"
+                        programFiles32 + File.separator + "OpenOffice.org 3",
+                        programFiles32 + File.separator + "OpenOffice 4"
                     });
             //@formatter:on
 


### PR DESCRIPTION
I would like to contribute to the fork. This is a very small change, I just added the OpenOffice 4 default HOME, so that I can use the JODConverter with OpenOffice 4.X.

Regards, Jose Luis.