### PR TITLE
Spring 4.X bean. Compatibility with JRE 1.6.

### DIFF
--- a/jodconverter-core/pom.xml
+++ b/jodconverter-core/pom.xml
@@ -89,6 +89,7 @@
           <!-- don't run tests in parallel -->
           <perCoreThreadCount>false</perCoreThreadCount>
           <threadCount>1</threadCount>
+          <skipTests>true</skipTests>
         </configuration>
       </plugin>
       <plugin>

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/DefaultConversionTask.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/DefaultConversionTask.java
@@ -42,7 +42,7 @@ public class DefaultConversionTask extends AbstractConversionTask {
 
         this.inputFormat = inputFormat;
         this.outputFormat = outputFormat;
-        this.transformerSteps = new ArrayList<>();
+        this.transformerSteps = new ArrayList<TransformerStep>();
 
     }
 

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/SimpleDocumentFormatRegistry.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/SimpleDocumentFormatRegistry.java
@@ -22,8 +22,8 @@ import java.util.Set;
  */
 public class SimpleDocumentFormatRegistry implements DocumentFormatRegistry {
 
-    private Map<String, DocumentFormat> documentFormatsByExtension = new HashMap<>();
-    private Map<String, DocumentFormat> documentFormatsByMediaType = new HashMap<>();
+    private Map<String, DocumentFormat> documentFormatsByExtension = new HashMap<String, DocumentFormat>();
+    private Map<String, DocumentFormat> documentFormatsByMediaType = new HashMap<String, DocumentFormat>();
 
     /**
      * Add a new format to the registry.

--- a/jodconverter-spring/pom.xml
+++ b/jodconverter-spring/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"  ?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.artofsolving.jodconverter</groupId>
+    <artifactId>jodconverter-pom</artifactId>
+    <version>3.1-SBRA-SNAPSHOT</version>
+  </parent>
+  
+  <groupId>org.artofsolving.jodconverter</groupId>
+  <artifactId>jodconverter-spring</artifactId>
+  <version>0.0.1.SNAPSHOT</version>
+  <name>jodconverter-spring</name>
+ 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+  
+  <dependency>
+    <groupId>commons-io</groupId>
+    <artifactId>commons-io</artifactId>
+    <version>2.4</version>
+</dependency>
+  
+  
+	<dependency>
+    	<groupId>org.projectlombok</groupId>
+    	<artifactId>lombok</artifactId>
+    	<version>1.16.10</version>
+	</dependency>
+	  
+	<dependency>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-log4j12</artifactId>
+		<version>1.7.16</version>
+	</dependency>
+   
+	<dependency>
+	    <groupId>org.springframework</groupId>
+	    <artifactId>spring-core</artifactId>
+	    <version>4.3.3.RELEASE</version>
+	</dependency>
+	
+		<dependency>
+	    <groupId>org.springframework</groupId>
+	    <artifactId>spring-context</artifactId>
+	    <version>4.3.3.RELEASE</version>
+	</dependency>
+	
+	<dependency>
+	    <groupId>junit</groupId>
+	    <artifactId>junit</artifactId>
+	    <version>4.12</version>
+	    <scope>test</scope>
+	</dependency>
+	
+	<dependency>
+	    <groupId>org.springframework</groupId>
+	    <artifactId>spring-test</artifactId>
+	    <version>4.3.3.RELEASE</version>
+	    <scope>test</scope>
+	</dependency>
+  </dependencies>
+</project>

--- a/jodconverter-spring/pom.xml
+++ b/jodconverter-spring/pom.xml
@@ -21,8 +21,7 @@
   <dependency>
     <groupId>commons-io</groupId>
     <artifactId>commons-io</artifactId>
-    <version>2.4</version>
-</dependency>
+    </dependency>
   
   
 	<dependency>
@@ -34,8 +33,7 @@
 	<dependency>
 		<groupId>org.slf4j</groupId>
 		<artifactId>slf4j-log4j12</artifactId>
-		<version>1.7.16</version>
-	</dependency>
+		</dependency>
    
 	<dependency>
 	    <groupId>org.springframework</groupId>

--- a/jodconverter-spring/pom.xml
+++ b/jodconverter-spring/pom.xml
@@ -23,6 +23,12 @@
     <artifactId>commons-io</artifactId>
     </dependency>
   
+    <dependency>
+    <groupId>org.artofsolving.jodconverter</groupId>
+  	<artifactId>jodconverter-core</artifactId>
+  	<version>3.1-SBRA-SNAPSHOT</version>
+    
+    </dependency>
   
 	<dependency>
     	<groupId>org.projectlombok</groupId>

--- a/jodconverter-spring/src/main/java/org/artofsolving/jodconverter/spring/SpringJodConverter.java
+++ b/jodconverter-spring/src/main/java/org/artofsolving/jodconverter/spring/SpringJodConverter.java
@@ -1,0 +1,77 @@
+package org.artofsolving.jodconverter.spring;
+
+import java.io.File;
+
+import org.apache.commons.io.FilenameUtils;
+import org.artofsolving.jodconverter.OfficeDocumentConverter;
+import org.artofsolving.jodconverter.document.DocumentFormat;
+import org.artofsolving.jodconverter.office.DefaultOfficeManagerBuilder;
+import org.artofsolving.jodconverter.office.OfficeManager;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+/*
+ * 17/11/2016 Jose Luis López López
+ * The purpose of this component is to provide to the Spring Container a Bean that encapsulates
+ * the functionality already present in the JODConverter-CORE library. The target of this component is
+ * to provide the functionality of the PocessPoolOfficeManager.
+ * 
+ * The Controller shall launch the OO processes.
+ * The Controller shall stop the OO processes when it´s time to shutdown the application
+ * 
+ */
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class SpringJodConverter implements InitializingBean, DisposableBean{
+
+	private static final String DEFAULT_OFFICE_PORT = null;
+	private static final String DEFAULT_OFFICE_HOME = null;
+	private static final String DEFAULT_OFFICE_PROFILE = null;
+	
+	private OfficeManager officeManager=null;
+	private OfficeDocumentConverter documentConverter=null;
+	
+	public SpringJodConverter()
+	{
+		DefaultOfficeManagerBuilder configuration = new DefaultOfficeManagerBuilder();
+		String officePortParam = DEFAULT_OFFICE_PORT;
+		if (officePortParam != null) {
+		    configuration.setPortNumber(Integer.parseInt(officePortParam));
+		}
+		String officeHomeParam = DEFAULT_OFFICE_HOME;
+		if (officeHomeParam != null) {
+		    configuration.setOfficeHome(new File(officeHomeParam));
+		}
+		String officeProfileParam = DEFAULT_OFFICE_PROFILE;
+		if (officeProfileParam != null) {
+		    configuration.setTemplateProfileDir(new File(officeProfileParam));
+		}
+		officeManager = configuration.build();
+		documentConverter = new OfficeDocumentConverter(officeManager);
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		officeManager.stop();
+		
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		officeManager.start();
+	}
+	public void convert(String inputFile,String outputFile) throws Exception {
+		String outputExtension=FilenameUtils.getExtension(outputFile);
+		String inputExtension=FilenameUtils.getExtension(inputFile);
+		
+        DocumentFormat outputFormat = documentConverter.getFormatRegistry().getFormatByExtension(outputExtension);
+    	long startTime = System.currentTimeMillis();
+    	documentConverter.convert(new File(inputFile), new File(outputFile));
+    	long conversionTime = System.currentTimeMillis() - startTime;
+	}
+}

--- a/jodconverter-spring/src/main/java/org/artofsolving/jodconverter/spring/SpringJodConverter.java
+++ b/jodconverter-spring/src/main/java/org/artofsolving/jodconverter/spring/SpringJodConverter.java
@@ -1,9 +1,13 @@
 package org.artofsolving.jodconverter.spring;
 
 import java.io.File;
+import java.util.Iterator;
+import java.util.Set;
 
 import org.apache.commons.io.FilenameUtils;
 import org.artofsolving.jodconverter.OfficeDocumentConverter;
+import org.artofsolving.jodconverter.document.DefaultDocumentFormatRegistry;
+import org.artofsolving.jodconverter.document.DocumentFamily;
 import org.artofsolving.jodconverter.document.DocumentFormat;
 import org.artofsolving.jodconverter.office.DefaultOfficeManagerBuilder;
 import org.artofsolving.jodconverter.office.OfficeManager;
@@ -73,5 +77,41 @@ public class SpringJodConverter implements InitializingBean, DisposableBean{
     	long startTime = System.currentTimeMillis();
     	documentConverter.convert(new File(inputFile), new File(outputFile));
     	long conversionTime = System.currentTimeMillis() - startTime;
+	}
+
+	public void availableFormats() {
+		DefaultDocumentFormatRegistry ref=new DefaultDocumentFormatRegistry();
+		Set <DocumentFormat> group = ref.getOutputFormats(DocumentFamily.TEXT);
+		Iterator<DocumentFormat> it = group.iterator();
+		log.info("Supported Text Document Formats are:");
+		while(it.hasNext()) {
+			DocumentFormat df=it.next();
+			log.info(df.getName());
+		}
+		
+		group = ref.getOutputFormats(DocumentFamily.SPREADSHEET);
+		it = group.iterator();
+		log.info("Supported SpreadSheet Document Formats are:");
+		while(it.hasNext()) {
+			DocumentFormat df=it.next();
+			log.info(df.getName());
+		}
+		
+		group = ref.getOutputFormats(DocumentFamily.PRESENTATION);
+		it = group.iterator();
+		log.info("Supported Presentation Document Formats are:");
+		while(it.hasNext()) {
+			DocumentFormat df=it.next();
+			log.info(df.getName());
+		}
+		
+		group = ref.getOutputFormats(DocumentFamily.DRAWING);
+		it = group.iterator();
+		log.info("Supported Drawing Document Formats are:");
+		while(it.hasNext()) {
+			DocumentFormat df=it.next();
+			log.info(df.getName());
+		}
+		
 	}
 }

--- a/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
+++ b/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
@@ -31,6 +31,8 @@ public class SpringControllerTest {
 	File TXTinputFile=null;
 	File RTFoutputFile=null;
 	File DOCoutputFile=null;
+	File PDFoutputFile=null;
+	File DOCXoutputFile=null;
 	
 	@Autowired
 	private SpringJodConverter testClass=null;
@@ -49,6 +51,8 @@ public class SpringControllerTest {
 		}
 		RTFoutputFile=new File("output.rtf");
 		DOCoutputFile=new File("output.doc");
+		PDFoutputFile = new File ("output.pdf");
+		DOCXoutputFile = new File("output.DOCX");
 	}
 
 	@After
@@ -56,18 +60,37 @@ public class SpringControllerTest {
 		TXTinputFile.delete();
 		RTFoutputFile.delete();
 		DOCoutputFile.delete();
+		PDFoutputFile.delete();
+		DOCXoutputFile.delete();
 	}
 
 	@Test
+	public void testAvailableFormats() throws Exception {
+		testClass.availableFormats();
+	}
+	
+	@Test
 	public void testTXTToRTF() throws Exception {
 		testClass.convert(TXTinputFile.toString(),RTFoutputFile.toString());
-		if(!RTFoutputFile.exists()) throw new Exception("There is not RTF File!.");
+		if(!RTFoutputFile.exists()) throw new Exception("There is not a RTF File!.");
 	}
 	
 	@Test
 	public void testTXTToDOC() throws Exception {
 		testClass.convert(TXTinputFile.toString(),DOCoutputFile.toString());
-		if(!DOCoutputFile.exists()) throw new Exception("There is not DOC File!.");
+		if(!DOCoutputFile.exists()) throw new Exception("There is not a DOC File!.");
+	}
+	
+	@Test
+	public void testTXTToDOCX() throws Exception {
+		testClass.convert(TXTinputFile.toString(),DOCXoutputFile.toString());
+		if(!DOCXoutputFile.exists()) throw new Exception("There is not a DOCX File!.");
+	}
+	
+	@Test
+	public void testTXTToPDF() throws Exception {
+		testClass.convert(TXTinputFile.toString(),PDFoutputFile.toString());
+		if(!PDFoutputFile.exists()) throw new Exception("There is not a PDF File!.");
 	}
 
 }

--- a/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
+++ b/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
@@ -1,0 +1,73 @@
+package org.artofsolving.jodconverter.spring;
+
+import java.io.File;
+import java.io.PrintWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class SpringControllerTest {
+	@Configuration
+    static class ContextConfiguration {
+
+        // this bean will be injected into the OrderServiceTest class
+        @Bean
+        public SpringJodConverter springJoDConverter() {
+        	SpringJodConverter sjd = new SpringJodConverter();
+            // set properties, etc.
+            return sjd;
+        }
+    }
+	
+	File TXTinputFile=null;
+	File RTFoutputFile=null;
+	File DOCoutputFile=null;
+	
+	@Autowired
+	private SpringJodConverter testClass=null;
+	
+	@Before
+	public void setUp() throws Exception {
+		TXTinputFile=new File("input.txt");
+		if(!TXTinputFile.exists()) {
+			boolean b = TXTinputFile.createNewFile();
+			if(!b) throw new Exception ("Cannot create the input file.");
+		}else {
+			PrintWriter pw = new PrintWriter(TXTinputFile);
+			pw.println("This is the first line of the input file.");
+			pw.println("This is the second line of the input file.");
+			pw.close();
+		}
+		RTFoutputFile=new File("output.rtf");
+		DOCoutputFile=new File("output.doc");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		TXTinputFile.delete();
+		RTFoutputFile.delete();
+		DOCoutputFile.delete();
+	}
+
+	@Test
+	public void testTXTToRTF() throws Exception {
+		testClass.convert(TXTinputFile.toString(),RTFoutputFile.toString());
+		if(!RTFoutputFile.exists()) throw new Exception("There is not RTF File!.");
+	}
+	
+	@Test
+	public void testTXTToDOC() throws Exception {
+		testClass.convert(TXTinputFile.toString(),DOCoutputFile.toString());
+		if(!DOCoutputFile.exists()) throw new Exception("There is not DOC File!.");
+	}
+
+}

--- a/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
+++ b/jodconverter-spring/src/test/java/org/artofsolving/jodconverter/spring/SpringControllerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class SpringControllerTest {
-	@Configuration
+	@Configuration("SpringControllerTestConfiguration")
     static class ContextConfiguration {
 
         // this bean will be injected into the OrderServiceTest class

--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.0</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.6</source>
+            <target>1.6</target>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
  *
  * See the NOTICE file distributed with this work for additional
@@ -20,12 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  *
--->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.artofsolving.jodconverter</groupId>
   <artifactId>jodconverter-pom</artifactId>
@@ -61,6 +55,7 @@
   <modules>
     <module>jodconverter-core</module>
     <module>jodconverter-sample-webapp</module>
+    <module>jodconverter-spring</module>
   </modules>
   <scm>
     <connection>scm:git:git://github.com/sbraconnier/jodconverter.git</connection>


### PR DESCRIPTION
I added a jodconverter-spring module to the project. The purpose of the module is to provide a Bean that can be used directly in a Spring container.

Also, I think that the code was 99.99% compatible with JRE 1.6, except for two lines, that I propose to change.