### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ configure(javaprojects) {
 apply plugin: "io.codearte.nexus-staging"
 
 nexusStaging {  
-  username = ossrhUsername
-  password = ossrhPassword
+  username = findProperty('ossrhUsername')
+  password = findProperty('ossrhPassword')
 }
 
 // Apply the configuration for the published projects only


### PR DESCRIPTION
Regular developers don't have access to the credentials used to publish artifacts to Sonatype (and they don't need them).

This commit changes `ossrhUsername` and `ossrhPassword` properties so they're referenced only when needed.

This is commit 1/2 to fix issue #11.