### PR TITLE
Update publish-projects.gradle

### DIFF
--- a/gradle/publish-projects.gradle
+++ b/gradle/publish-projects.gradle
@@ -8,6 +8,7 @@ apply plugin: 'maven'
 
 // Signature of artifacts
 signing {
+  required { gradle.taskGraph.hasTask("uploadArchives") }
   sign configurations.archives
 }
 
@@ -20,12 +21,12 @@ uploadArchives {
             
       // Target repository
       repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
       }
             
       // Snapshot repository
       snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(userName: ossrhUsername, password: ossrhPassword)
+        authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
       }
             
       pom.project {


### PR DESCRIPTION
Regular developers don't have access to the credentials used to publish artifacts to Sonatype (and they don't need them).

This commit changes ossrhUsername and ossrhPassword properties so they're referenced only when needed.
It also restricts signing to goals that include uploading archives.

This is commit 2/2 to fix issue #11.