### PR TITLE
🐧 Supporting more platforms

### DIFF
--- a/jodconverter-local/src/main/java/org/jodconverter/process/UnixProcessManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/process/UnixProcessManager.java
@@ -73,7 +73,7 @@ public class UnixProcessManager extends AbstractProcessManager {
   protected String[] getRunningProcessesCommand(final String process) {
 
     return new String[] {
-      "/bin/bash", "-c", "/bin/ps -e -o pid,args | /bin/grep " + process + " | /bin/grep -v grep"
+      "/bin/sh", "-c", "/bin/ps -e -o pid,args | /bin/grep " + process + " | /bin/grep -v grep"
     };
   }
 


### PR DESCRIPTION
Bash is not available on all linux distributions (Alpine Linux for example). Using sh instead, which symlinks to the system shell.