### PR TITLE
Added inheritIO() call to ProcessBuilder

### DIFF
--- a/jodconverter-local/src/main/java/org/jodconverter/office/OfficeProcess.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/office/OfficeProcess.java
@@ -290,7 +290,7 @@ class OfficeProcess {
     // to retrieve the LibreOffice pid. But is it reliable ? And it would
     // not work with Apache OpenOffice.
 
-    return new ProcessBuilder(command);
+    return new ProcessBuilder(command).inheritIO();
   }
 
   /**


### PR DESCRIPTION
I found that when terminating soffice processes the streams on the processes where never being consumed or closed.