### PR TITLE
Build spring-boot configuration metadata into jar #295

### DIFF
--- a/buildSrc/src/main/java/org/jodconverter/Deps.java
+++ b/buildSrc/src/main/java/org/jodconverter/Deps.java
@@ -51,7 +51,7 @@ public class Deps {
       "org.springframework.boot:spring-boot-dependencies:" + springBootVersion;
   public static final String springBootStarter = "org.springframework.boot:spring-boot-starter";
   public static final String springBootConfigurationProcessor =
-      "org.springframework.boot:spring-boot-configuration-processor";
+      "org.springframework.boot:spring-boot-configuration-processor:" + springBootVersion;
   public static final String springBootStarterTest =
       "org.springframework.boot:spring-boot-starter-test";
 

--- a/jodconverter-spring-boot-starter/build.gradle
+++ b/jodconverter-spring-boot-starter/build.gradle
@@ -6,8 +6,7 @@ description = 'Spring Boot integration module of the Java OpenDocument Converter
 dependencies {
     compileOnly project(":jodconverter-local")
     compileOnly project(":jodconverter-remote")
-
-    compileOnly Deps.springBootConfigurationProcessor
+    annotationProcessor Deps.springBootConfigurationProcessor
 
     implementation Deps.springBootStarter
 


### PR DESCRIPTION
Change the annotation processor for config metadata to be in the annotationProcessor dependency configuration.  Add the version to the dependency since automatic dependency version resolution doesn't work for some reason when it is annotationProcessor.
Fixes #295 