### PR TITLE
Feature/improvement - manual restart

### DIFF
--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPool.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPool.java
@@ -47,7 +47,7 @@ import org.jodconverter.core.util.StringUtils;
  * {@link #execute(org.jodconverter.core.task.OfficeTask)} function is called.
  */
 public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerPoolEntry>
-    implements OfficeManager, TemporaryFileMaker {
+    implements OfficeManager, OfficeRestarter, TemporaryFileMaker {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOfficeManagerPool.class);
 
@@ -185,7 +185,7 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
 
     if (manager == null) {
       throw new OfficeException(
-          String.format("No office manager available after %d millisec", taskQueueTimeout));
+          String.format("No office manager availablef ater %d millisec", taskQueueTimeout));
     }
     LOGGER.debug("Office manager acquired successfully from the pool.");
     return manager;
@@ -267,6 +267,76 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
         "tempfile_"
             + tempFileCounter.getAndIncrement()
             + (StringUtils.isBlank(extension) ? "" : "." + extension));
+  }
+
+  /**
+   * Restarts all idle processes in the pool. Only processes that are not currently handling tasks
+   * will be restarted.
+   *
+   * <p>The restart behavior depends on the configured {@link
+   * org.jodconverter.local.office.RestartStrategy}. With automatic restart strategy, processes
+   * restart immediately in background threads. With manual restart strategy, restarts are queued
+   * and must be triggered externally.
+   *
+   * @return The number of idle processes that were requested to restart.
+   */
+  @Override
+  public synchronized int restartIdleProcesses() {
+    int restartedCount = 0;
+
+    if (poolState.get() != POOL_STARTED) {
+      return restartedCount;
+    }
+
+    for (final E entry : entries) {
+      if (entry.isIdle()) {
+        entry.requestRestart();
+        restartedCount++;
+      }
+    }
+
+    LOGGER.info("Requested restart for {} idle process(es)", restartedCount);
+    return restartedCount;
+  }
+
+  /**
+   * Gets the number of idle (available) processes in the pool.
+   *
+   * @return The count of idle processes.
+   */
+  @Override
+  public synchronized int getIdleCount() {
+    if (poolState.get() != POOL_STARTED) {
+      return 0;
+    }
+
+    int idleCount = 0;
+    for (final E entry : entries) {
+      if (entry.isIdle()) {
+        idleCount++;
+      }
+    }
+    return idleCount;
+  }
+
+  /**
+   * Gets the number of busy (unavailable) processes in the pool.
+   *
+   * @return The count of busy processes.
+   */
+  @Override
+  public synchronized int getBusyCount() {
+    if (poolState.get() != POOL_STARTED) {
+      return 0;
+    }
+
+    int busyCount = 0;
+    for (final E entry : entries) {
+      if (!entry.isIdle()) {
+        busyCount++;
+      }
+    }
+    return busyCount;
   }
 
   /**

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPool.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPool.java
@@ -185,7 +185,7 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
 
     if (manager == null) {
       throw new OfficeException(
-          String.format("No office manager availablef ater %d millisec", taskQueueTimeout));
+          String.format("No office manager available after %d millisec", taskQueueTimeout));
     }
     LOGGER.debug("Office manager acquired successfully from the pool.");
     return manager;
@@ -281,22 +281,25 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
    * @return The number of idle processes that were requested to restart.
    */
   @Override
-  public synchronized int restartIdleProcesses() {
-    int restartedCount = 0;
+  public int restartIdleProcesses() {
 
-    if (poolState.get() != POOL_STARTED) {
+    synchronized (this) {
+      int restartedCount = 0;
+
+      if (poolState.get() != POOL_STARTED) {
+        return restartedCount;
+      }
+
+      for (final E entry : entries) {
+        if (entry.isIdle()) {
+          entry.requestRestart();
+          restartedCount++;
+        }
+      }
+
+      LOGGER.info("Requested restart for {} idle process(es)", restartedCount);
       return restartedCount;
     }
-
-    for (final E entry : entries) {
-      if (entry.isIdle()) {
-        entry.requestRestart();
-        restartedCount++;
-      }
-    }
-
-    LOGGER.info("Requested restart for {} idle process(es)", restartedCount);
-    return restartedCount;
   }
 
   /**
@@ -305,18 +308,21 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
    * @return The count of idle processes.
    */
   @Override
-  public synchronized int getIdleCount() {
-    if (poolState.get() != POOL_STARTED) {
-      return 0;
-    }
+  public int getIdleCount() {
 
-    int idleCount = 0;
-    for (final E entry : entries) {
-      if (entry.isIdle()) {
-        idleCount++;
+    synchronized (this) {
+      if (poolState.get() != POOL_STARTED) {
+        return 0;
       }
+
+      int idleCount = 0;
+      for (final E entry : entries) {
+        if (entry.isIdle()) {
+          idleCount++;
+        }
+      }
+      return idleCount;
     }
-    return idleCount;
   }
 
   /**
@@ -325,18 +331,21 @@ public abstract class AbstractOfficeManagerPool<E extends AbstractOfficeManagerP
    * @return The count of busy processes.
    */
   @Override
-  public synchronized int getBusyCount() {
-    if (poolState.get() != POOL_STARTED) {
-      return 0;
-    }
+  public int getBusyCount() {
 
-    int busyCount = 0;
-    for (final E entry : entries) {
-      if (!entry.isIdle()) {
-        busyCount++;
+    synchronized (this) {
+      if (poolState.get() != POOL_STARTED) {
+        return 0;
       }
+
+      int busyCount = 0;
+      for (final E entry : entries) {
+        if (!entry.isIdle()) {
+          busyCount++;
+        }
+      }
+      return busyCount;
     }
-    return busyCount;
   }
 
   /**

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPoolEntry.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/AbstractOfficeManagerPoolEntry.java
@@ -206,6 +206,25 @@ public abstract class AbstractOfficeManagerPoolEntry implements OfficeManager {
   }
 
   /**
+   * Checks if this manager entry is currently idle (available to execute tasks).
+   *
+   * @return {@code true} if the manager is idle and available, {@code false} if it's busy or
+   *     unavailable.
+   */
+  public boolean isIdle() {
+    return taskExecutor.isAvailable();
+  }
+
+  /**
+   * Requests a restart of this manager entry. The actual restart behavior depends on the
+   * implementation and configured restart strategy.
+   *
+   * <p>This method should only be called when the entry is idle. Calling it on a busy entry may
+   * have implementation-specific behavior.
+   */
+  public abstract void requestRestart();
+
+  /**
    * Allow subclasses to perform operation when the office manager is started.
    *
    * @throws OfficeException If an error occurred while starting the manager.

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/OfficeRestarter.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/OfficeRestarter.java
@@ -1,32 +1,59 @@
+/*
+ * Copyright (c) 2004 - 2012; Mirko Nasato and contributors
+ *               2016 - 2022; Simon Braconnier and contributors
+ *               2022 - present; JODConverter
+ *
+ * This file is part of JODConverter - Java OpenDocument Converter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jodconverter.core.office;
 
+/**
+ * An interface that provides capabilities to restart office processes in a pool. This is
+ * particularly useful for managing the lifecycle of office processes, allowing for the restart of
+ * idle processes to ensure optimal performance and resource management. The implementation of this
+ * interface can vary based on the underlying office suite and the specific requirements of the
+ * application, but it generally includes methods to restart idle processes and to retrieve the
+ * count of idle and busy processes in the pool.
+ */
 public interface OfficeRestarter {
 
-    /**
-     * Restarts all idle processes in the pool. Only processes that are not currently handling tasks
-     * will be restarted.
-     *
-     * <p>The restart behavior depends on the configured {@link
-     * org.jodconverter.local.office.RestartStrategy}. With automatic restart strategy, processes
-     * restart immediately in background threads. With manual restart strategy, restarts are queued
-     * and must be triggered externally.
-     *
-     * @return The number of idle processes that were requested to restart.
-     */
-    int restartIdleProcesses();
+  /**
+   * Restarts all idle processes in the pool. Only processes that are not currently handling tasks
+   * will be restarted.
+   *
+   * <p>The restart behavior depends on the configured {@link
+   * org.jodconverter.local.office.RestartStrategy}. With automatic restart strategy, processes
+   * restart immediately in background threads. With manual restart strategy, restarts are queued
+   * and must be triggered externally.
+   *
+   * @return The number of idle processes that were requested to restart.
+   */
+  int restartIdleProcesses();
 
-    /**
-     * Gets the number of idle (available) processes in the pool.
-     *
-     * @return The count of idle processes.
-     */
-    int getIdleCount();
+  /**
+   * Gets the number of idle (available) processes in the pool.
+   *
+   * @return The count of idle processes.
+   */
+  int getIdleCount();
 
-    /**
-     * Gets the number of busy (unavailable) processes in the pool.
-     *
-     * @return The count of busy processes.
-     */
-    int getBusyCount();
-
+  /**
+   * Gets the number of busy (unavailable) processes in the pool.
+   *
+   * @return The count of busy processes.
+   */
+  int getBusyCount();
 }

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/OfficeRestarter.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/OfficeRestarter.java
@@ -1,0 +1,32 @@
+package org.jodconverter.core.office;
+
+public interface OfficeRestarter {
+
+    /**
+     * Restarts all idle processes in the pool. Only processes that are not currently handling tasks
+     * will be restarted.
+     *
+     * <p>The restart behavior depends on the configured {@link
+     * org.jodconverter.local.office.RestartStrategy}. With automatic restart strategy, processes
+     * restart immediately in background threads. With manual restart strategy, restarts are queued
+     * and must be triggered externally.
+     *
+     * @return The number of idle processes that were requested to restart.
+     */
+    int restartIdleProcesses();
+
+    /**
+     * Gets the number of idle (available) processes in the pool.
+     *
+     * @return The count of idle processes.
+     */
+    int getIdleCount();
+
+    /**
+     * Gets the number of busy (unavailable) processes in the pool.
+     *
+     * @return The count of busy processes.
+     */
+    int getBusyCount();
+
+}

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/SuspendableThreadPoolExecutor.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/SuspendableThreadPoolExecutor.java
@@ -73,4 +73,18 @@ public class SuspendableThreadPoolExecutor extends ThreadPoolExecutor {
       suspendLock.unlock();
     }
   }
+
+  /**
+   * Checks if this executor is currently available to execute tasks.
+   *
+   * @return {@code true} if the executor is available, {@code false} otherwise.
+   */
+  public synchronized boolean isAvailable() {
+    suspendLock.lock();
+    try {
+      return available;
+    } finally {
+      suspendLock.unlock();
+    }
+  }
 }

--- a/jodconverter-core/src/main/java/org/jodconverter/core/office/SuspendableThreadPoolExecutor.java
+++ b/jodconverter-core/src/main/java/org/jodconverter/core/office/SuspendableThreadPoolExecutor.java
@@ -79,12 +79,15 @@ public class SuspendableThreadPoolExecutor extends ThreadPoolExecutor {
    *
    * @return {@code true} if the executor is available, {@code false} otherwise.
    */
-  public synchronized boolean isAvailable() {
-    suspendLock.lock();
-    try {
-      return available;
-    } finally {
-      suspendLock.unlock();
+  public boolean isAvailable() {
+
+    synchronized (this) {
+      suspendLock.lock();
+      try {
+        return available;
+      } finally {
+        suspendLock.unlock();
+      }
     }
   }
 }

--- a/jodconverter-core/src/test/java/org/jodconverter/core/office/SimpleOfficeManagerPoolEntry.java
+++ b/jodconverter-core/src/test/java/org/jodconverter/core/office/SimpleOfficeManagerPoolEntry.java
@@ -61,6 +61,11 @@ class SimpleOfficeManagerPoolEntry extends AbstractOfficeManagerPoolEntry {
     // Nothing to stop here.
   }
 
+  @Override
+  public void requestRestart() {
+    // No-op for test implementation
+  }
+
   // Change visibility in order to be able to call while testing
   @Override
   public void cancelTask() {

--- a/jodconverter-local/src/integTest/java/org/jodconverter/local/office/ExternalOfficeManagerITest.java
+++ b/jodconverter-local/src/integTest/java/org/jodconverter/local/office/ExternalOfficeManagerITest.java
@@ -73,6 +73,7 @@ class ExternalOfficeManagerITest {
             DEFAULT_EXISTING_PROCESS_ACTION,
             true,
             DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+            RestartStrategy.automatic(),
             connection);
     manager.start();
     final OfficeConnection conn =

--- a/jodconverter-local/src/integTest/java/org/jodconverter/local/office/LocalOfficeManagerPoolEntryITest.java
+++ b/jodconverter-local/src/integTest/java/org/jodconverter/local/office/LocalOfficeManagerPoolEntryITest.java
@@ -86,6 +86,7 @@ class LocalOfficeManagerPoolEntryITest {
                   DEFAULT_EXISTING_PROCESS_ACTION,
                   DEFAULT_START_FAIL_FAST,
                   DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+                  RestartStrategy.automatic(),
                   new OfficeConnection(CONNECT_URL)));
       try {
         poolEntry.start();
@@ -121,6 +122,7 @@ class LocalOfficeManagerPoolEntryITest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               DEFAULT_START_FAIL_FAST,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
       final LocalOfficeManagerPoolEntry poolEntry =
           new LocalOfficeManagerPoolEntry(
@@ -192,6 +194,7 @@ class LocalOfficeManagerPoolEntryITest {
                   DEFAULT_EXISTING_PROCESS_ACTION,
                   DEFAULT_START_FAIL_FAST,
                   DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+                  RestartStrategy.automatic(),
                   new OfficeConnection(CONNECT_URL)));
       try {
         poolEntry.start();
@@ -242,6 +245,7 @@ class LocalOfficeManagerPoolEntryITest {
                   DEFAULT_EXISTING_PROCESS_ACTION,
                   DEFAULT_START_FAIL_FAST,
                   DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+                  RestartStrategy.automatic(),
                   new OfficeConnection(CONNECT_URL)));
       try {
         poolEntry.start();

--- a/jodconverter-local/src/integTest/java/org/jodconverter/local/office/LocalOfficeProcessManagerITest.java
+++ b/jodconverter-local/src/integTest/java/org/jodconverter/local/office/LocalOfficeProcessManagerITest.java
@@ -78,6 +78,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.KILL,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               new OfficeConnection(CONNECT_URL));
       try {
         manager.start();
@@ -112,6 +113,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.FAIL,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               new OfficeConnection(CONNECT_URL));
       try {
 
@@ -150,6 +152,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.CONNECT,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               new OfficeConnection(CONNECT_URL));
       try {
 
@@ -186,6 +189,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.CONNECT_OR_KILL,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               new OfficeConnection(CONNECT_URL));
       try {
         manager.start();
@@ -245,6 +249,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.CONNECT_OR_KILL,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
       managerRef.set(manager);
       try {
@@ -282,6 +287,7 @@ class LocalOfficeProcessManagerITest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
       try {
         manager.start();
@@ -322,6 +328,7 @@ class LocalOfficeProcessManagerITest {
               ExistingProcessAction.KILL,
               true,
               true,
+              RestartStrategy.automatic(),
               connection);
       try {
         manager.start();
@@ -344,6 +351,7 @@ class LocalOfficeProcessManagerITest {
                 ExistingProcessAction.FAIL,
                 true,
                 DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+                RestartStrategy.automatic(),
                 connection);
 
         // Find a way to assert that an exception is thrown (check the log).
@@ -366,6 +374,7 @@ class LocalOfficeProcessManagerITest {
                 ExistingProcessAction.CONNECT_OR_KILL,
                 true,
                 DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+                RestartStrategy.automatic(),
                 connection);
 
       } finally {
@@ -396,6 +405,7 @@ class LocalOfficeProcessManagerITest {
             DEFAULT_EXISTING_PROCESS_ACTION,
             DEFAULT_START_FAIL_FAST,
             DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+            RestartStrategy.automatic(),
             connection);
     processManager.start();
     final long limit = start + START_WAIT_TIMEOUT;

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/AutomaticRestartStrategy.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/AutomaticRestartStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2004 - 2012; Mirko Nasato and contributors
+ *               2016 - 2022; Simon Braconnier and contributors
+ *               2022 - present; JODConverter
+ *
+ * This file is part of JODConverter - Java OpenDocument Converter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jodconverter.local.office;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An automatic restart strategy that immediately executes restart actions. This is the default
+ * behavior that maintains backward compatibility with previous versions.
+ */
+public final class AutomaticRestartStrategy implements RestartStrategy {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AutomaticRestartStrategy.class);
+
+  @Override
+  public void onRestartRequired(
+      final @NonNull RestartReason reason,
+      final @NonNull Runnable restartAction,
+      final @Nullable AvailabilityCallback availabilityCallback) {
+
+    LOGGER.debug("Automatic restart triggered for reason: {}", reason);
+
+    restartAction.run();
+  }
+}

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/ExternalOfficeManagerPoolEntry.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/ExternalOfficeManagerPoolEntry.java
@@ -169,6 +169,11 @@ class ExternalOfficeManagerPoolEntry extends AbstractOfficeManagerPoolEntry {
     connectionManager.disconnect();
   }
 
+  @Override
+  public void requestRestart() {
+    reconnect();
+  }
+
   private void reconnect() {
 
     // The manager is no longer available

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManager.java
@@ -124,6 +124,7 @@ public final class LocalOfficeManager
       final ExistingProcessAction existingProcessAction,
       final boolean startFailFast,
       final boolean keepAliveOnShutdown,
+      final RestartStrategy restartStrategy,
       final int maxTasksPerProcess,
       final long taskExecutionTimeout,
       final long taskQueueTimeout) {
@@ -149,6 +150,7 @@ public final class LocalOfficeManager
                             existingProcessAction,
                             startFailFast,
                             keepAliveOnShutdown,
+                            restartStrategy,
                             new OfficeConnection(officeUrl))))
             .collect(Collectors.toList()));
   }
@@ -174,6 +176,7 @@ public final class LocalOfficeManager
     private ExistingProcessAction existingProcessAction = DEFAULT_EXISTING_PROCESS_ACTION;
     private boolean startFailFast = DEFAULT_START_FAIL_FAST;
     private boolean keepAliveOnShutdown = DEFAULT_KEEP_ALIVE_ON_SHUTDOWN;
+    private RestartStrategy restartStrategy;
     private int maxTasksPerProcess = DEFAULT_MAX_TASKS_PER_PROCESS;
 
     // Private constructor so only LocalOfficeManager can initialize an instance of this builder.
@@ -193,6 +196,9 @@ public final class LocalOfficeManager
       }
       if (runAsArgs == null) {
         runAsArgs = Collections.emptyList();
+      }
+      if (restartStrategy == null) {
+        restartStrategy = RestartStrategy.automatic();
       }
 
       // Validate the directories we are working with
@@ -227,6 +233,7 @@ public final class LocalOfficeManager
               existingProcessAction,
               startFailFast,
               keepAliveOnShutdown,
+              restartStrategy,
               maxTasksPerProcess,
               taskExecutionTimeout,
               taskQueueTimeout);
@@ -590,6 +597,24 @@ public final class LocalOfficeManager
             String.format(
                 "maxTasksPerProcess %s must be greater than or equal to 0", maxTasksPerProcess));
         this.maxTasksPerProcess = maxTasksPerProcess;
+      }
+      return this;
+    }
+
+    /**
+     * Specifies the restart strategy to use for handling office process restarts. The strategy
+     * determines whether restarts happen automatically in the background or are deferred for manual
+     * triggering.
+     *
+     * <p>&nbsp; <b><i>Default</i></b>: Automatic restart strategy
+     *
+     * @param restartStrategy The restart strategy to use.
+     * @return This builder instance.
+     */
+    public @NonNull Builder restartStrategy(final @Nullable RestartStrategy restartStrategy) {
+
+      if (restartStrategy != null) {
+        this.restartStrategy = restartStrategy;
       }
       return this;
     }

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManagerPoolEntry.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeManagerPoolEntry.java
@@ -76,6 +76,14 @@ class LocalOfficeManagerPoolEntry extends AbstractOfficeManagerPoolEntry {
     this.officeProcessManager = officeProcessManager;
     this.maxTasksPerProcess = maxTasksPerProcess;
 
+    // Set the availability callback so that the process manager can mark this entry
+    // as unavailable when a manual restart is requested
+    officeProcessManager.setAvailabilityCallback(
+        () -> {
+          LOGGER.info("Marking pool entry unavailable due to pending restart");
+          setAvailable(false);
+        });
+
     // This connection event listener will be notified when a connection is established or
     // closed/lost to/from an office instance.
     final OfficeConnectionEventListener connectionEventListener =
@@ -198,6 +206,11 @@ class LocalOfficeManagerPoolEntry extends AbstractOfficeManagerPoolEntry {
 
     // Now we can stop the running office process
     officeProcessManager.stop();
+  }
+
+  @Override
+  public void requestRestart() {
+    restart();
   }
 
   private void restart() {

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeProcessManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeProcessManager.java
@@ -289,8 +289,8 @@ class LocalOfficeProcessManager {
    * Restarts the office process when there is a timeout while executing a task.
    *
    * <p>The function will forcibly kill the office process via the configured {@link
-   * RestartStrategy}. With automatic restart strategy, this happens immediately. With manual restart
-   * strategy, the kill action is queued and must be triggered externally.
+   * RestartStrategy}. With automatic restart strategy, this happens immediately. With manual
+   * restart strategy, the kill action is queued and must be triggered externally.
    *
    * @see LocalOfficeManagerPoolEntry
    */

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeProcessManager.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/LocalOfficeProcessManager.java
@@ -75,6 +75,8 @@ class LocalOfficeProcessManager {
   private final ExistingProcessAction existingProcessAction;
   private final boolean startFailFast;
   private final boolean keepAliveOnShutdown;
+  private final RestartStrategy restartStrategy;
+  private RestartStrategy.AvailabilityCallback availabilityCallback;
 
   /**
    * Creates a new manager with the specified configuration.
@@ -103,6 +105,7 @@ class LocalOfficeProcessManager {
    *     shutdown. If set to {@code true}, the {@link #stop()} will only disconnect from the office
    *     process, which will stay alive. If set to {@code false}, the office process will be stopped
    *     gracefully (or killed if it could not be stopped gracefully).
+   * @param restartStrategy The strategy to use for handling office process restarts.
    * @param connection The object that will manage the connection to the office process.
    */
   /* default */ LocalOfficeProcessManager(
@@ -118,6 +121,7 @@ class LocalOfficeProcessManager {
       final ExistingProcessAction existingProcessAction,
       final boolean startFailFast,
       final boolean keepAliveOnShutdown,
+      final RestartStrategy restartStrategy,
       final OfficeConnection connection) {
 
     this.officeUrl = officeUrl;
@@ -131,6 +135,7 @@ class LocalOfficeProcessManager {
     this.existingProcessAction = existingProcessAction;
     this.startFailFast = startFailFast;
     this.keepAliveOnShutdown = keepAliveOnShutdown;
+    this.restartStrategy = restartStrategy;
     this.connection = connection;
 
     executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("jodconverter-offprocmng"));
@@ -138,6 +143,17 @@ class LocalOfficeProcessManager {
         new File(
             workingDir,
             ".jodconverter_" + officeUrl.getConnectString().replace(',', '_').replace('=', '-'));
+  }
+
+  /**
+   * Sets the availability callback that will be invoked when a manual restart is requested. This
+   * allows the pool entry to be marked as unavailable immediately when a restart is needed.
+   *
+   * @param availabilityCallback The callback to invoke.
+   */
+  /* default */ void setAvailabilityCallback(
+      final RestartStrategy.AvailabilityCallback availabilityCallback) {
+    this.availabilityCallback = availabilityCallback;
   }
 
   /**
@@ -209,66 +225,86 @@ class LocalOfficeProcessManager {
   /**
    * Restarts an office process.
    *
-   * <p>The task of restarting the process and connecting to it is executed by a single thread
-   * {@link ExecutorService} and thus, the current {@code restart()} function returns immediately.
-   * The restart will be done as soon as the executor is available to execute the task.
+   * <p>The task of restarting the process and connecting to it is executed via the configured
+   * {@link RestartStrategy}. With automatic restart strategy, the restart happens immediately in a
+   * background thread. With manual restart strategy, the restart is queued and must be triggered
+   * externally.
    */
   /* default */ void restart() {
-    LOGGER.info("Restarting...");
+    LOGGER.info("Restart requested...");
 
-    executor.execute(
-        () -> {
-          // On clean restart, we won't delete the instance profile directory,
-          // causing a faster start of an office process.
-          stopProcess(false);
-          try {
-            startProcessAndConnect(true);
-          } catch (OfficeException ex) {
-            LOGGER.error("Could not restart the office process.", ex);
-          }
-        });
+    restartStrategy.onRestartRequired(
+        RestartReason.MAX_TASKS_REACHED,
+        () ->
+            executor.execute(
+                () -> {
+                  LOGGER.info("Executing restart...");
+                  // On clean restart, we won't delete the instance profile directory,
+                  // causing a faster start of an office process.
+                  stopProcess(false);
+                  try {
+                    startProcessAndConnect(true);
+                  } catch (OfficeException ex) {
+                    LOGGER.error("Could not restart the office process.", ex);
+                  }
+                }),
+        availabilityCallback);
   }
 
   /**
    * Restarts the office process when the connection is lost.
    *
-   * <p>The task of restarting the process and connecting to it is executed by a single thread
-   * {@link ExecutorService} and thus, the current {@code restartDueToLostConnection()} function
-   * returns immediately.
+   * <p>The task of restarting the process and connecting to it is executed via the configured
+   * {@link RestartStrategy}. With automatic restart strategy, the restart happens immediately in a
+   * background thread. With manual restart strategy, the restart is queued and must be triggered
+   * externally.
    */
   /* default */ void restartDueToLostConnection() {
-    LOGGER.info("Restarting due to lost connection...");
+    LOGGER.info("Restart requested due to lost connection...");
 
-    executor.execute(
-        () -> {
-          LOGGER.debug("Connection lost unexpectedly");
+    restartStrategy.onRestartRequired(
+        RestartReason.CONNECTION_LOST,
+        () ->
+            executor.execute(
+                () -> {
+                  LOGGER.info("Executing restart due to lost connection...");
+                  LOGGER.debug("Connection lost unexpectedly");
 
-          // Since we have lost the connection unexpectedly, it could mean that
-          // the office process has crashed. Thus, we want a clean instance profile
-          // directory on restart.
-          ensureProcessExited(true);
-          try {
-            startProcessAndConnect(false);
-          } catch (OfficeException ex) {
-            LOGGER.error(
-                "Could not restart the office process after an unexpected lost connection.", ex);
-          }
-        });
+                  // Since we have lost the connection unexpectedly, it could mean that
+                  // the office process has crashed. Thus, we want a clean instance profile
+                  // directory on restart.
+                  ensureProcessExited(true);
+                  try {
+                    startProcessAndConnect(false);
+                  } catch (OfficeException ex) {
+                    LOGGER.error(
+                        "Could not restart the office process after an unexpected lost connection.",
+                        ex);
+                  }
+                }),
+        availabilityCallback);
   }
 
   /**
    * Restarts the office process when there is a timeout while executing a task.
    *
-   * <p>The function will only forcibly kill the office process, causing an unexpected disconnection
-   * and later restart.
+   * <p>The function will forcibly kill the office process via the configured {@link
+   * RestartStrategy}. With automatic restart strategy, this happens immediately. With manual restart
+   * strategy, the kill action is queued and must be triggered externally.
    *
    * @see LocalOfficeManagerPoolEntry
    */
   /* default */ void restartDueToTaskTimeout() {
-    LOGGER.info("Restarting due to task timeout...");
+    LOGGER.info("Restart requested due to task timeout...");
 
-    // This will cause unexpected disconnection and later restart.
-    forciblyTerminateProcess();
+    restartStrategy.onRestartRequired(
+        RestartReason.TASK_TIMEOUT,
+        () -> {
+          LOGGER.info("Executing restart due to task timeout...");
+          // This will cause unexpected disconnection and later restart.
+          forciblyTerminateProcess();
+        },
+        availabilityCallback);
   }
 
   /**

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/ManualRestartStrategy.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/ManualRestartStrategy.java
@@ -23,7 +23,6 @@ package org.jodconverter.local.office;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -42,11 +41,15 @@ public final class ManualRestartStrategy implements RestartStrategy {
   private final List<PendingRestart> pendingRestarts = new CopyOnWriteArrayList<>();
   private final List<RestartEventListener> listeners = new CopyOnWriteArrayList<>();
 
+  /**
+   * A class ot encapsulate pending restart requests, including the reason for the restart and the
+   * action to execute when the restart is triggered.
+   */
   private static class PendingRestart {
     private final RestartReason reason;
     private final Runnable restartAction;
 
-    PendingRestart(final RestartReason reason, final Runnable restartAction) {
+    /* default */ PendingRestart(final RestartReason reason, final Runnable restartAction) {
       this.reason = reason;
       this.restartAction = restartAction;
     }
@@ -78,14 +81,14 @@ public final class ManualRestartStrategy implements RestartStrategy {
       final @Nullable AvailabilityCallback availabilityCallback) {
 
     LOGGER.info("Manual restart requested for reason: {}", reason);
-    
+
     // Immediately mark the pool entry as unavailable if callback is provided
     // This prevents new tasks from being submitted while waiting for manual restart
     if (availabilityCallback != null) {
       LOGGER.debug("Marking pool entry as unavailable due to pending restart");
       availabilityCallback.markUnavailable();
     }
-    
+
     final PendingRestart pending = new PendingRestart(reason, restartAction);
     pendingRestarts.add(pending);
 
@@ -159,18 +162,13 @@ public final class ManualRestartStrategy implements RestartStrategy {
    *
    * @return The number of restarts executed.
    */
-  public int executeAllPendingRestarts(@Nullable final Executor executor) {
+  public int executeAllPendingRestarts() {
     int count = 0;
 
     while (!pendingRestarts.isEmpty()) {
       final PendingRestart pending = pendingRestarts.remove(0);
 
-      if (executor != null) {
-        executor.execute(() -> executeRestart(pending));
-      } else {
-        executeRestart(pending);
-      }
-
+      executeRestart(pending);
 
       count++;
     }
@@ -195,13 +193,13 @@ public final class ManualRestartStrategy implements RestartStrategy {
     try {
       pending.restartAction.run();
       success = true;
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.error("Error executing restart action", ex);
     } finally {
       for (final RestartEventListener listener : listeners) {
         try {
           listener.onRestartExecuted(pending.reason, success);
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
           LOGGER.error("Error notifying restart listener", ex);
         }
       }

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/ManualRestartStrategy.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/ManualRestartStrategy.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2004 - 2012; Mirko Nasato and contributors
+ *               2016 - 2022; Simon Braconnier and contributors
+ *               2022 - present; JODConverter
+ *
+ * This file is part of JODConverter - Java OpenDocument Converter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jodconverter.local.office;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A manual restart strategy that collects restart requests and allows external code to trigger
+ * restarts. This strategy is useful when you want to control when office processes are restarted,
+ * for example, to batch restarts or to restart during maintenance windows.
+ */
+public final class ManualRestartStrategy implements RestartStrategy {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ManualRestartStrategy.class);
+
+  private final List<PendingRestart> pendingRestarts = new CopyOnWriteArrayList<>();
+  private final List<RestartEventListener> listeners = new CopyOnWriteArrayList<>();
+
+  private static class PendingRestart {
+    private final RestartReason reason;
+    private final Runnable restartAction;
+
+    PendingRestart(final RestartReason reason, final Runnable restartAction) {
+      this.reason = reason;
+      this.restartAction = restartAction;
+    }
+  }
+
+  /** Listener interface for restart events. */
+  public interface RestartEventListener {
+    /**
+     * Called when a restart is requested but not yet executed.
+     *
+     * @param reason The reason for the restart.
+     */
+    void onRestartRequested(RestartReason reason);
+
+    /**
+     * Called when a restart has been executed.
+     *
+     * @param reason The reason for the restart.
+     * @param success {@code true} if the restart completed without throwing an exception, {@code
+     *     false} otherwise.
+     */
+    void onRestartExecuted(RestartReason reason, boolean success);
+  }
+
+  @Override
+  public void onRestartRequired(
+      final @NonNull RestartReason reason,
+      final @NonNull Runnable restartAction,
+      final @Nullable AvailabilityCallback availabilityCallback) {
+
+    LOGGER.info("Manual restart requested for reason: {}", reason);
+    
+    // Immediately mark the pool entry as unavailable if callback is provided
+    // This prevents new tasks from being submitted while waiting for manual restart
+    if (availabilityCallback != null) {
+      LOGGER.debug("Marking pool entry as unavailable due to pending restart");
+      availabilityCallback.markUnavailable();
+    }
+    
+    final PendingRestart pending = new PendingRestart(reason, restartAction);
+    pendingRestarts.add(pending);
+
+    for (final RestartEventListener listener : listeners) {
+      try {
+        listener.onRestartRequested(reason);
+      } catch (final Exception ex) {
+        LOGGER.error("Error notifying restart listener", ex);
+      }
+    }
+  }
+
+  /**
+   * Adds a listener to be notified of restart events.
+   *
+   * @param listener The listener to add.
+   */
+  public void addRestartEventListener(final @NonNull RestartEventListener listener) {
+    listeners.add(listener);
+  }
+
+  /**
+   * Removes a previously added listener.
+   *
+   * @param listener The listener to remove.
+   */
+  public void removeRestartEventListener(final @NonNull RestartEventListener listener) {
+    listeners.remove(listener);
+  }
+
+  /**
+   * Gets the number of pending restart requests.
+   *
+   * @return The number of pending restarts.
+   */
+  public int getPendingRestartCount() {
+    return pendingRestarts.size();
+  }
+
+  /**
+   * Gets a list of pending restart reasons.
+   *
+   * @return A list of reasons for pending restarts.
+   */
+  public @NonNull List<RestartReason> getPendingRestartReasons() {
+    final List<RestartReason> reasons = new ArrayList<>();
+    for (final PendingRestart pending : pendingRestarts) {
+      reasons.add(pending.reason);
+    }
+    return reasons;
+  }
+
+  /**
+   * Executes the next pending restart request.
+   *
+   * @return {@code true} if a restart was executed, {@code false} if there were no pending
+   *     restarts.
+   */
+  public boolean executeNextRestart() {
+    if (pendingRestarts.isEmpty()) {
+      return false;
+    }
+
+    final PendingRestart pending = pendingRestarts.remove(0);
+    executeRestart(pending);
+    return true;
+  }
+
+  /**
+   * Executes all pending restart requests.
+   *
+   * @return The number of restarts executed.
+   */
+  public int executeAllPendingRestarts(@Nullable final Executor executor) {
+    int count = 0;
+
+    while (!pendingRestarts.isEmpty()) {
+      final PendingRestart pending = pendingRestarts.remove(0);
+
+      if (executor != null) {
+        executor.execute(() -> executeRestart(pending));
+      } else {
+        executeRestart(pending);
+      }
+
+
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Clears all pending restart requests without executing them.
+   *
+   * @return The number of restart requests that were cleared.
+   */
+  public int clearPendingRestarts() {
+    final int count = pendingRestarts.size();
+    pendingRestarts.clear();
+    LOGGER.info("Cleared {} pending restart requests", count);
+    return count;
+  }
+
+  private void executeRestart(final PendingRestart pending) {
+    LOGGER.info("Executing manual restart for reason: {}", pending.reason);
+    boolean success = false;
+    try {
+      pending.restartAction.run();
+      success = true;
+    } catch (Exception ex) {
+      LOGGER.error("Error executing restart action", ex);
+    } finally {
+      for (final RestartEventListener listener : listeners) {
+        try {
+          listener.onRestartExecuted(pending.reason, success);
+        } catch (Exception ex) {
+          LOGGER.error("Error notifying restart listener", ex);
+        }
+      }
+    }
+  }
+}

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartReason.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartReason.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2004 - 2012; Mirko Nasato and contributors
+ *               2016 - 2022; Simon Braconnier and contributors
+ *               2022 - present; JODConverter
+ *
+ * This file is part of JODConverter - Java OpenDocument Converter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jodconverter.local.office;
+
+/**
+ * Enumeration of reasons why an office process restart may be required.
+ */
+public enum RestartReason {
+
+  /** The maximum number of tasks per process has been reached. */
+  MAX_TASKS_REACHED,
+
+  /** The connection to the office process was lost unexpectedly. */
+  CONNECTION_LOST,
+
+  /** A task execution timeout occurred. */
+  TASK_TIMEOUT
+}

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartReason.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartReason.java
@@ -20,9 +20,7 @@
 
 package org.jodconverter.local.office;
 
-/**
- * Enumeration of reasons why an office process restart may be required.
- */
+/** Enumeration of reasons why an office process restart may be required. */
 public enum RestartReason {
 
   /** The maximum number of tasks per process has been reached. */

--- a/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartStrategy.java
+++ b/jodconverter-local/src/main/java/org/jodconverter/local/office/RestartStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004 - 2012; Mirko Nasato and contributors
+ *               2016 - 2022; Simon Braconnier and contributors
+ *               2022 - present; JODConverter
+ *
+ * This file is part of JODConverter - Java OpenDocument Converter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jodconverter.local.office;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * A restart strategy determines how office process restarts are handled. Implementations can choose
+ * to restart immediately, defer restarts for manual triggering, or implement custom restart logic.
+ */
+public interface RestartStrategy {
+
+  /**
+   * Callback interface to control the availability of the office manager pool entry during restart
+   * operations.
+   */
+  @FunctionalInterface
+  interface AvailabilityCallback {
+    /**
+     * Marks the pool entry as unavailable. This prevents new tasks from being submitted to a
+     * process that is being restarted or needs to be restarted.
+     */
+    void markUnavailable();
+  }
+
+  /**
+   * Called when an office process restart is required.
+   *
+   * @param reason The reason why the restart is required.
+   * @param restartAction The action to execute to perform the restart. This runnable encapsulates
+   *     the actual restart logic.
+   * @param availabilityCallback Optional callback to control pool entry availability. If the
+   *     restart is deferred (manual strategy), this callback should be invoked immediately to mark
+   *     the pool entry as unavailable. For automatic restarts, this callback is typically not
+   *     needed as the restart executes immediately.
+   */
+  void onRestartRequired(
+      @NonNull final RestartReason reason,
+      @NonNull final Runnable restartAction,
+      @Nullable final AvailabilityCallback availabilityCallback);
+
+  /**
+   * Creates an automatic restart strategy that immediately executes restart actions. This is the
+   * default behavior that maintains backward compatibility.
+   *
+   * @return A new automatic restart strategy instance.
+   */
+  static @NonNull RestartStrategy automatic() {
+    return new AutomaticRestartStrategy();
+  }
+
+  /**
+   * Creates a manual restart strategy that collects restart requests and allows external triggering
+   * of restarts.
+   *
+   * @return A new manual restart strategy instance.
+   */
+  static @NonNull RestartStrategy manual() {
+    return new ManualRestartStrategy();
+  }
+}

--- a/jodconverter-local/src/test/java/org/jodconverter/local/office/LocalOfficeProcessManagerReflectTest.java
+++ b/jodconverter-local/src/test/java/org/jodconverter/local/office/LocalOfficeProcessManagerReflectTest.java
@@ -75,6 +75,7 @@ class LocalOfficeProcessManagerReflectTest {
             DEFAULT_EXISTING_PROCESS_ACTION,
             DEFAULT_START_FAIL_FAST,
             DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+            RestartStrategy.automatic(),
             connection);
 
     assertThatExceptionOfType(OfficeException.class)
@@ -118,6 +119,7 @@ class LocalOfficeProcessManagerReflectTest {
             DEFAULT_EXISTING_PROCESS_ACTION,
             DEFAULT_START_FAIL_FAST,
             DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+            RestartStrategy.automatic(),
             connection);
 
     // TODO: Check that the error message if properly logged.
@@ -150,6 +152,7 @@ class LocalOfficeProcessManagerReflectTest {
             DEFAULT_EXISTING_PROCESS_ACTION,
             DEFAULT_START_FAIL_FAST,
             DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+            RestartStrategy.automatic(),
             connection);
 
     assertThatCode(() -> ReflectionTestUtils.invokeMethod(manager, "forciblyTerminateProcess"))

--- a/jodconverter-local/src/test/java/org/jodconverter/local/office/LocalOfficeProcessManagerTest.java
+++ b/jodconverter-local/src/test/java/org/jodconverter/local/office/LocalOfficeProcessManagerTest.java
@@ -79,6 +79,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               DEFAULT_START_FAIL_FAST,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThat(manager.getConnection()).isEqualTo(connection);
@@ -107,6 +108,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               new OfficeConnection(url) {
                 @Override
                 public void connect() throws OfficeConnectionException {
@@ -138,6 +140,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       final AtomicReference<OfficeException> ex = new AtomicReference<>();
@@ -189,6 +192,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               true,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThatCode(manager::stop).doesNotThrowAnyException();
@@ -215,6 +219,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               false,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThatCode(manager::start).doesNotThrowAnyException();
@@ -240,6 +245,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               false,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThatCode(manager::stop).doesNotThrowAnyException();
@@ -270,6 +276,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               false,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThatCode(manager::stop).doesNotThrowAnyException();
@@ -297,6 +304,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               false,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       final AtomicReference<OfficeException> ex = new AtomicReference<>();
@@ -352,6 +360,7 @@ class LocalOfficeProcessManagerTest {
               DEFAULT_EXISTING_PROCESS_ACTION,
               false,
               DEFAULT_KEEP_ALIVE_ON_SHUTDOWN,
+              RestartStrategy.automatic(),
               connection);
 
       assertThatCode(manager::restart).doesNotThrowAnyException();

--- a/jodconverter-remote/src/main/java/org/jodconverter/remote/office/RemoteOfficeManagerPoolEntry.java
+++ b/jodconverter-remote/src/main/java/org/jodconverter/remote/office/RemoteOfficeManagerPoolEntry.java
@@ -316,6 +316,11 @@ class RemoteOfficeManagerPoolEntry extends AbstractOfficeManagerPoolEntry {
     // Nothing to stop here.
   }
 
+  @Override
+  public void requestRestart() {
+    // No-op for remote office manager - there's no process to restart
+  }
+
   private KeyStore loadStore(
       final String store,
       final String storePassword,

--- a/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
+++ b/jodconverter-spring-boot-starter/src/main/java/org/jodconverter/boot/autoconfigure/JodConverterLocalAutoConfiguration.java
@@ -74,7 +74,7 @@ public class JodConverterLocalAutoConfiguration {
   }
 
   // Creates the OfficeManager bean.
-  private OfficeManager createOfficeManager(final ProcessManager processManager) {
+  private LocalOfficeManager createOfficeManager(final ProcessManager processManager) {
 
     final LocalOfficeManager.Builder builder =
         LocalOfficeManager.builder()
@@ -146,7 +146,7 @@ public class JodConverterLocalAutoConfiguration {
 
   @Bean(name = "localOfficeManager", initMethod = "start", destroyMethod = "stop")
   @ConditionalOnMissingBean(name = "localOfficeManager")
-  /* default */ OfficeManager localOfficeManager(final ProcessManager processManager) {
+  /* default */ LocalOfficeManager localOfficeManager(final ProcessManager processManager) {
 
     return createOfficeManager(processManager);
   }


### PR DESCRIPTION
Hi there! Follows up the detailed description of the proposed changes. I am always available for any further discussions or questions :)

### **Problem**

When an office process needs to restart (due to max tasks reached, a lost connection, or a task timeout), JODConverter always restarts it immediately in a background thread. This works for simple use cases but becomes a limitation in production environments:

- No control over restart timing — applications that process long-running or batched document conversions cannot defer restarts until a safe moment, risking disruption to in-flight work.

- No visibility into restart events — there is no API to inspect why a restart was triggered or to be notified when one occurs, making monitoring and diagnostics difficult.

- No way to coordinate restarts with application logic — for example, deferring restarts to low-traffic windows or waiting for a batch to complete before cycling a process.

### **Proposed solution**

Introduce a RestartStrategy abstraction that decouples the decision to restart from the execution of the restart. Two built-in implementations are provided:

_AutomaticRestartStrategy_ (default) -> Preserves current behavior — restarts execute immediately. Fully backward-compatible.
_ManualRestartStrategy_ -> Queues restart requests for external triggering. The pool entry is immediately marked unavailable (no new tasks assigned), but the actual process restart is deferred until the consumer explicitly invokes it.

**New APIs**

_OfficeRestarter_ interface (implemented by _AbstractOfficeManagerPool_):

- _restartIdleProcesses()_ — restart only idle processes, leaving busy ones untouched.
- _getIdleCount()_ / _getBusyCount()_ — pool observability for health checks and scaling.

_ManualRestartStrategy_:

- _getPendingRestartCount()_ / _getPendingRestartReasons()_ — inspect queued restarts and their reasons.
- _executeNextRestart()_ / _executeAllPendingRestarts()_ — trigger restarts on demand.
- _clearPendingRestarts()_ — discard pending restarts.
- _RestartEventListener_ — lifecycle callbacks (onRestartRequested, onRestartExecuted) for monitoring and alerting.

_RestartReason_ enum:  `MAX_TASKS_REACHED`, `CONNECTION_LOST`, `TASK_TIMEOUT`


> The Builder integration defaults to RestartStrategy.automatic() when not specified — no breaking changes for existing users.

### **Backward compatibility**

- Default behavior is unchanged; the automatic strategy is applied if none is configured.
- All existing constructor contracts and Spring Boot auto-configuration continue to work without modification.
- RemoteOfficeManagerPoolEntry.requestRestart() is a no-op (no local process to manage), consistent with the remote module's design.